### PR TITLE
Add tabs to the home page

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -76,15 +76,13 @@
   <!-- End Google Tag Manager (noscript) -->
 
   <header id="navigation" class="p-navigation">
-    <div class="row">
+    <div class="p-navigation__row">
       <div class="p-navigation__banner">
         <div class="p-navigation__logo u-vertically-center">
-          <a class="p-navigation__link" href="/" style="color:white">
+          <a class="p-navigation__link" href="/" style="color:white;">
             MicroStack
           </a>
         </div>
-        <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-        <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
       </div>
       <nav class="p-navigation__nav">
         <span class="u-off-screen">
@@ -131,6 +129,6 @@
     </div>
   </footer>
   <script src="/js/build/global-nav/global-nav.js"></script>
-	<script>canonicalGlobalNav.createNav({ showLogins: false, maxWidth:"72rem" });</script>
+	<script>canonicalGlobalNav.createNav({ maxWidth:"72rem" });</script>
 </body>
 </html>

--- a/_sass/_settings.scss
+++ b/_sass/_settings.scss
@@ -4,6 +4,8 @@ $mine-shaft: #333333;
 $persian-red: #ce2d2d;
 $color-accent: $ubuntu-orange;
 
+$theme-default-nav: dark;
+
 $color-navigation-background: $mine-shaft;
 $color-navigation-active-bar: $ubuntu-orange;
 

--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -19,21 +19,43 @@
   background-color: $ubuntu-orange;
 }
 
-.p-navigation__logo {
-  font-weight: 400;
-  margin-right: $sph-inner--large;
+.p-navigation {
+  .p-navigation__row {
+    padding: 0;
 
-  @media only screen and (max-width: $breakpoint-medium) {
-    margin-bottom: -12px;
-    margin-top: 0;
-    max-height: 3rem;
+    .p-navigation__banner {
+      padding: 0 $sph-inner--large;
+
+      .p-navigation__logo {
+        font-weight: 400;
+        margin-right: 0;
+        
+      }
+
+      .p-navigation__toggle {
+        &--open,
+        &--close {
+          font-weight: 400;
+        }
+      }
+    }
+    
+    .p-navigation__link a {
+      height: 100%;
+      padding-left: $sph-inner--large ;
+      padding-right: $sph-inner--large ;
+    }
   }
 }
 
-.p-navigation__toggle {
-  &--open,
-  &--close {
-    font-weight: 400;
+.p-tab {
+  color: $color-mid-dark;
+
+  &:focus,
+  &:hover,
+  &.active {
+    background-color: $color-light;
+    text-decoration: none;
   }
 }
 

--- a/docs/pro-tips.md
+++ b/docs/pro-tips.md
@@ -8,16 +8,6 @@ title: "Pro tips"
 This page consists of a collection of tips and optional configurations that may
 improve your experience with MicroStack.
 
-## Launch a VM
-
-```bash
-microstack.launch cirros --name test
-```
-
-Your VM is up and running now. You should see a message like:
-
-Access your server with `ssh -i /home/ubuntu/.ssh/id_microstack cirros@10.20.20.3`
-
 ## Try a different version, or a beta, or a daily build
 
 Snaps are published in [channels](https://snapcraft.io/docs/channels) which are made up of a track (or major version), and an expected level of stability. Try          `snap info microstack` to see what versions are currently published. You can run:

--- a/docs/pro-tips.md
+++ b/docs/pro-tips.md
@@ -8,6 +8,32 @@ title: "Pro tips"
 This page consists of a collection of tips and optional configurations that may
 improve your experience with MicroStack.
 
+## Launch a VM
+
+```bash
+microstack.launch cirros --name test
+```
+
+Your VM is up and running now. You should see a message like:
+
+Access your server with `ssh -i /home/ubuntu/.ssh/id_microstack cirros@10.20.20.3`
+
+## Try a different version, or a beta, or a daily build
+
+Snaps are published in [channels](https://snapcraft.io/docs/channels) which are made up of a track (or major version), and an expected level of stability. Try          `snap info microstack` to see what versions are currently published. You can run:
+
+```bash
+sudo snap refresh --channel=latest/beta microstack
+```
+
+or
+
+```bash
+sudo snap refresh --channel=1.11/stable microstack
+```
+
+to get the required version.
+
 ## Kernel tweaks
 
 OpenStack can potentially run a lot of processes and open a lot of network

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
           Install and run OpenStack on Linux in minutes. Made for developers and great for edge, IoT, and appliances.
         </p>
         <p>
-          <a class="p-button--positive is-inline" href="#get-started">Get started</a>&nbsp;&nbsp;for Linux, Windows or macOS
+          <a class="p-button--positive is-inline" href="#get-started">Get started</a><span style="padding-left: .5rem;">for Linux, Windows or macOS</span>
         </p>
       </div>
       <div class="col-4 u-align--center u-hide--small">
@@ -156,7 +156,7 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
       <a id="tab-one" href="#tab-one__content"
         class="col-small-2 col-medium-2 col-4 p-card p-tab u-align--center u-vertically-center js-tab" role="tab">
         <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg" style="height: 90px; margin-top: 1rem;" alt="">
-        <h4 class="p-heading--five p-tab__title">Linux</h4>
+        <p class="p-heading--four" class="p-heading--five p-tab__title">Linux</p>
       </a>
 
       <a id="tab-two" href="#tab-two__content"
@@ -174,16 +174,33 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
       <div class="col-6 js-tab__content" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one">
         <ol class="p-stepped-list u-no-margin--left">
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Install the microkstack snap</h3>
+            <h3 class="p-stepped-list__title">Install the microstack snap</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
-                value="sudo snap install microstack --classic --edge" readonly="readonly">
+              <input class="p-code-copyable__input" value="sudo snap install microstack --classic --edge" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
 
             <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a
                 href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
+
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" value="sudo microstack.init --auto" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Launch a VM</h3>
+
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" value="microstack.launch cirros --name test" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+            <p>Your VM is up and running now. You should see a message like:</p>
+            <p>Access your server with <code class="highlighter-rouge">ssh -i /home/ubuntu/.ssh/id_microstack cirros@10.20.20.3</code></p>
           </li>
         </ol>
         <p>
@@ -203,26 +220,21 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
             </p>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Start a multipass vm</h3>
+            <h3 class="p-stepped-list__title">Start a multipass VM</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
-                value="multipass launch --name microkstack-vm --mem 8G --disk 40G" readonly="readonly">
+              <input class="p-code-copyable__input" value="multipass launch --name microstack-vm --mem 8G --disk 40G" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Install the MicroStack snap on that multipass vm</h3>
+            <h3 class="p-stepped-list__title">Install the MicroStack snap on that multipass VM</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
-                value="multipass exec microkstack-vm -- sudo snap install microstack --classic --edge"
+              <input class="p-code-copyable__input" value="multipass exec microstack-vm -- sudo snap install microstack --classic --edge"
                 readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
-
-            <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a
-                href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
           </li>
           <li class="p-stepped-list__item">
             <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
@@ -232,6 +244,16 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
                 value="sudo microstack.init --auto" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Launch a VM</h3>
+
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" value="microstack.launch cirros --name test" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+            <p>Your VM is up and running now. You should see a message like:</p>
+            <p>Access your server with <code class="highlighter-rouge">ssh -i /home/ubuntu/.ssh/id_microstack cirros@10.20.20.3</code></p>
           </li>
         </ol>
         <p>
@@ -251,35 +273,39 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
             </p>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Start a multipass vm</h3>
+            <h3 class="p-stepped-list__title">Start a multipass VM</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
-                value="multipass launch --name microkstack-vm --mem 8G --disk 40G" readonly="readonly">
+              <input class="p-code-copyable__input" value="multipass launch --name microstack-vm --mem 8G --disk 40G" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Install the MicroStack snap on that multipass vm</h3>
+            <h3 class="p-stepped-list__title">Install the MicroStack snap on that multipass VM</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
-                value="multipass exec microkstack-vm -- sudo snap install microstack --classic --edge"
+              <input class="p-code-copyable__input" value="multipass exec microstack-vm -- sudo snap install microstack --classic --edge"
                 readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
-
-            <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a
-                href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
           </li>
           <li class="p-stepped-list__item">
             <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
-                value="sudo microstack.init --auto" readonly="readonly">
+              <input class="p-code-copyable__input" value="sudo microstack.init --auto" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Launch a VM</h3>
+
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" value="microstack.launch cirros --name test" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+            <p>Your VM is up and running now. You should see a message like:</p>
+            <p>Access your server with <code class="highlighter-rouge">ssh -i /home/ubuntu/.ssh/id_microstack cirros@10.20.20.3</code></p>
           </li>
         </ol>
         <p>

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
             <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
+              <input class="p-code-copyable__input"
                 value="sudo microstack.init --auto" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>

--- a/index.html
+++ b/index.html
@@ -146,7 +146,6 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
       <h2>Get started with MicroStack</h2>
       <div class="p-notification--information">
         <p class="p-notification__response">
-          <span class="p-notification__status">Information:</span>
           MicroStack requires at least 8 GB of RAM and a multi-core processor.
         </p>
       </div>

--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
             <p class="p-stepped-list__content u-stepped-list-margin">
               <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download"
                 data-os="win-win">
-                <span class="p-link--external">Download Multipass for Windows</span>
+                Download Multipass for Windows
               </a>
             </p>
           </li>

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
       <h2>Get started with MicroStack</h2>
       <div class="p-notification--information">
         <p class="p-notification__response">
-          MicroStack requires at least 8 GB of RAM and a multi-core processor.
+          MicroStack requires at least 8 GB RAM and a multi-core processor.
         </p>
       </div>
       <h3>What OS are you developing on?</h3>

--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
             <p class="p-stepped-list__content u-stepped-list-margin">
               <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download"
                 data-os="mac">
-                <span class="p-link--external">Download Multipass for macOS</span>
+                Download Multipass for macOS
               </a>
             </p>
           </li>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
       </div>
       <div class="col-4 u-align--center u-hide--small">
         <img src="https://assets.ubuntu.com/v1/5a6af817-OpenStack-Logo-Vertical-white.svg" width="250"
-          alt="Certified Kubernetes" />
+          alt="" />
       </div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 ---
 layout: base
 title: "Multi-node OpenStack"
-description: "MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances."
+description: "MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation.
+Although made for developers, it is also suitable for edge, IoT and appliances."
 ---
 <main id="main-content">
 
@@ -14,57 +15,18 @@ description: "MicroStack is an upstream single-node OpenStack deployment which c
         <p class="p-heading--four u-sv3">
           Install and run OpenStack on Linux in minutes. Made for developers and great for edge, IoT, and appliances.
         </p>
+        <p>
+          <a class="p-button--positive is-inline" href="#get-started">Get started</a>&nbsp;&nbsp;for Linux, Windows or macOS
+        </p>
       </div>
       <div class="col-4 u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/5a6af817-OpenStack-Logo-Vertical-white.svg" width="250" alt="Certified Kubernetes" />
+        <img src="https://assets.ubuntu.com/v1/5a6af817-OpenStack-Logo-Vertical-white.svg" width="250"
+          alt="Certified Kubernetes" />
       </div>
     </div>
   </section>
 
-  <section class="p-strip is-shallow">
-    <div class="row p-divider">
-      <div class="col-4 p-divider__block u-align--center">
-        <h5>Linux</h5>
-        <a href="https://snapcraft.io/microstack" title="Get it from the Snap Store">
-          <img src="https://snapcraft.io/static/images/badges/en/snap-store-white.svg" alt="Get it from the Snap Store" width="200" style="padding-top: 2.2rem;" />
-        </a>
-      </div>
-      <div class="col-4 p-divider__block u-align--center">
-        <h5>Windows</h5>
-        <p>
-          <img src="https://assets.ubuntu.com/v1/11ecbd2d-2018-logo-windows.svg" width="150" alt="Windows 10 logo" />
-        </p>
-        <p>
-          <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="win-win">
-            <span class="p-link--external">Download Multipass</span>
-          </a>
-        </p>
-      </div>
-      <div class="col-4 p-divider__block u-align--center">
-        <h5>macOS <sup>*</sup></h5>
-        <p>
-          <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" width="150" alt="macOS logo" />
-        </p>
-        <p>
-          <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="mac">
-            <span class="p-link--external">Download Multipass</span>
-          </a>
-        </p>
-        <p>
-          <small>
-            <sup>*</sup> Yosemite 10.10.3 or later and a 2010 or newer Mac
-          </small>
-        </p>
-      </div>
-    </div>
-    <div class="u-fixed-width">
-      <a href="#instructions">
-        Learn how to install and start using MicroStack&nbsp;&rsaquo;
-      </a>
-    </div>
-  </section>
-
-  <section class="p-strip--light">
+  <section class="p-strip">
     <div class="row">
       <div class="col-8">
         <h2>OpenStack in a snap</h2>
@@ -84,197 +46,249 @@ description: "MicroStack is an upstream single-node OpenStack deployment which c
           <li class="p-list__item is-ticked">Neutron with OVS</li>
           <li class="p-list__item is-ticked">Dashboard</li>
           <li class="p-list__item is-ticked last-item">Metrics</li>
-        </div>
-        <div class="col-4">
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">GPGPU bindings</li>
-            <li class="p-list__item is-ticked">Clustering <small class="p-label--in-progress">BETA</small></li>
-          </ul>
-        </div>
       </div>
-      <div class="row">
-        <div class="col-8">
-          <p>
-            A full OpenStack in a single snap package! MicroStack is an upstream multi-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances. Do not wait anymore - grab MicroStack from the Snap Store and get your OpenStack running right away!
-          </p>
-          <p>
-            <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/microstack-get-started#0">Get started with MicroStack tutorial</a>
-          </p>
-        </div>
+      <div class="col-4">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">GPGPU bindings</li>
+          <li class="p-list__item is-ticked">Clustering <small class="p-label--in-progress">BETA</small></li>
+        </ul>
       </div>
-    </section>
+    </div>
+    <div class="row">
+      <div class="col-8">
+        <p>
+          A full OpenStack in a single snap package! MicroStack is an upstream multi-node OpenStack deployment which can
+          run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and
+          appliances. Do not wait anymore - grab MicroStack from the Snap Store and get your OpenStack running right
+          away!
+        </p>
+        <p>
+          <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/microstack-get-started#0">Get started
+            with MicroStack tutorial</a>
+        </p>
+      </div>
+    </div>
 
-    <section class="p-strip is-bordered">
-        <div class="row">
-          <h2>Reliable, small, ready to go</h2>
-        </div>
-        <div class="row">
-          <ul class="p-matrix u-clearfix">
-            <li class="p-matrix__item">
-              <div class="p-matrix__content">
-                <h3 class="p-matrix__title">Fast install</h3>
-                <div class="p-matrix__desc">
-                  <p>
-                    Get a full OpenStack system running in minutes.
-                  </p>
-                </div>
-              </div>
-            </li>
-            <li class="p-matrix__item">
-              <div class="p-matrix__content">
-                <h3 class="p-matrix__title">Secure</h3>
-                <div class="p-matrix__desc">
-                  <p>
-                    Runs safely on your laptop with state of the art isolation.
-                  </p>
-                </div>
-              </div>
-            </li>
-            <li class="p-matrix__item">
-              <div class="p-matrix__content">
-                <h3 class="p-matrix__title">Upstream</h3>
-                <div class="p-matrix__desc">
-                  <p>
-                    Pure upstream OpenStack delivered to your laptop.
-                  </p>
-                </div>
-              </div>
-            </li>
-            <li class="p-matrix__item">
-              <div class="p-matrix__content">
-                <h3 class="p-matrix__title">Complete</h3>
-                <div class="p-matrix__desc">
-                  <p>
-                    Includes all key OpenStack components: Keystone, Nova, Neutron, Glance, and Cinder.
-                  </p>
-                </div>
-              </div>
-            </li>
-            <li class="p-matrix__item">
-              <div class="p-matrix__content">
-                <h3 class="p-matrix__title">Featureful</h3>
-                <div class="p-matrix__desc">
-                  <p>
-                    All the cool things you probably want to try on a small, standard OpenStack are all built-in.
-                  </p>
-                </div>
-              </div>
-            </li>
-            <li class="p-matrix__item">
-              <div class="p-matrix__content">
-                <h3 class="p-matrix__title">Small</h3>
-                <div class="p-matrix__desc">
-                  <p>
-                    Use MicroStack in your CI/CD pipelines and get on with your day without headaches.
-                  </p>
-                </div>
-              </div>
-            </li>
-          </ul>
-        </div>
-      <div class="u-fixed-width">
-        <hr class="p-separator" />
-      </div>
-      <div class="row" id="instructions">
-        <div class="col-8">
-          <h2>Quick start</h2>
-          <p>
-            We recommend you use Ubuntu. On Mac or Windows, you can use <a class="p-link--external" href="https://multipass.run">Multipass</a> to give yourself Ubuntu VMs on demand. To install the <a class="p-link--external" href="https://snapcraft.io/microstack">MicroStack&nbsp;snap</a>:
-          </p>
-          <h3>Install MicroStack</h3>
+  </section>
 
-          <div class="p-notification--information">
-            <p class="p-notification__response">
-              <span class="p-notification__status">Information:</span>
-              MicroStack requires at least 8 GB of RAM and a multi-core processor.
+  <section class="p-strip--light">
+    <div class="row">
+      <h2>Reliable, small, ready to go</h2>
+    </div>
+    <div class="row">
+      <ul class="p-matrix u-clearfix">
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Fast install</h3>
+            <div class="p-matrix__desc">
+              <p>
+                Get a full OpenStack system running in minutes.
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Secure</h3>
+            <div class="p-matrix__desc">
+              <p>
+                Runs safely on your laptop with state of the art isolation.
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Upstream</h3>
+            <div class="p-matrix__desc">
+              <p>
+                Pure upstream OpenStack delivered to your laptop.
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Complete</h3>
+            <div class="p-matrix__desc">
+              <p>
+                Includes all key OpenStack components: Keystone, Nova, Neutron, Glance, and Cinder.
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Featureful</h3>
+            <div class="p-matrix__desc">
+              <p>
+                All the cool things you probably want to try on a small, standard OpenStack are all built-in.
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">Small</h3>
+            <div class="p-matrix__desc">
+              <p>
+                Use MicroStack in your CI/CD pipelines and get on with your day without headaches.
+              </p>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="p-strip is-bordered" id="get-started" role="tablist">
+    <div class="u-fixed-width">
+      <h2>Get started with MicroStack</h2>
+      <div class="p-notification--information">
+        <p class="p-notification__response">
+          <span class="p-notification__status">Information:</span>
+          MicroStack requires at least 8 GB of RAM and a multi-core processor.
+        </p>
+      </div>
+      <h3>What OS are you developing on?</h3>
+    </div>
+
+    <div class="row u-equal-height u-sv3">
+      <a id="tab-one" href="#tab-one__content"
+        class="col-small-2 col-medium-2 col-4 p-card p-tab u-align--center u-vertically-center js-tab" role="tab">
+        <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg" style="height: 90px; margin-top: 1rem;" alt="">
+        <h4 class="p-heading--five p-tab__title">Linux</h4>
+      </a>
+
+      <a id="tab-two" href="#tab-two__content"
+        class="col-small-2 col-medium-2 col-4 p-card p-tab u-align--center u-vertically-center js-tab" role="tab">
+        <img src="https://assets.ubuntu.com/v1/11ecbd2d-2018-logo-windows.svg" style="height: 145px;" alt="Windows">
+      </a>
+
+      <a id="tab-three" href="#tab-three__content"
+        class="col-small-2 col-medium-2 col-4 p-card p-tab u-align--center u-vertically-center js-tab" role="tab">
+        <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" style="height: 145px;" alt="macOS">
+      </a>
+    </div>
+
+    <div class="row">
+      <div class="col-6 js-tab__content" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one">
+        <ol class="p-stepped-list u-no-margin--left">
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Install the microkstack snap</h3>
+
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
+                value="sudo snap install microstack --classic --edge" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+
+            <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a
+                href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
+          </li>
+        </ol>
+        <p>
+          That’s it! Your OpenStack is ready.
+        </p>
+      </div>
+      <div class="col-6 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
+        <ol class="p-stepped-list u-no-margin--left">
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Install Multipass for Windows</h3>
+
+            <p class="p-stepped-list__content u-stepped-list-margin">
+              <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download"
+                data-os="win-win">
+                <span class="p-link--external">Download Multipass for Windows</span>
+              </a>
             </p>
-          </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Start a multipass vm</h3>
 
-          <h4>On Linux</h4>
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
+                value="multipass launch --name microkstack-vm --mem 8G --disk 40G" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Install the MicroStack snap on that multipass vm</h3>
 
-          <div class="p-code-copyable">
-            <input class="p-code-copyable__input" aria-label="sudo snap install microstack --classic --beta" value="sudo snap install microstack --classic --edge" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
+                value="multipass exec microkstack-vm -- sudo snap install microstack --classic --edge"
+                readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
 
-          <p>
-            Command <code>snap</code> not found? <a class="p-link--external" href="https://snapcraft.io/docs/core/install">Install snapd first</a>.
-          </p>
+            <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a
+                href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
 
-          <h4>On Windows and macOS</h4>
-
-          <p>
-            Install Multipass then start a multipass vm:
-          </p>
-          <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="multipass launch --name microkstack-vm --mem 8G --disk 40G" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-
-          <p>
-            Install the MicroStack snap on that multipass vm:
-          </p>
-          <div class="p-code-copyable u-sv3">
-            <input class="p-code-copyable__input" value="multipass exec microkstack-vm -- sudo snap install microstack --classic --edge" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-
-          <h3>Configure networks and OpenStack databases</h3>
-
-          <div class="p-code-copyable">
-            <input class="p-code-copyable__input" aria-label="sudo microstack.init" value="sudo microstack.init --auto" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-
-          <p>
-            That’s it! Your OpenStack is ready.
-          </p>
-        </div>
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
+                value="sudo microstack.init --auto" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+          </li>
+        </ol>
+        <p>
+          That’s it! Your OpenStack is ready.
+        </p>
       </div>
-      <div class="u-fixed-width">
-        <hr class="p-separator" />
-      </div>
-      <div class="row">
-        <div class="col-8">
-          <h2>
-            Useful tips
-          </h2>
-          <h3>
-            Launch a VM
-          </h3>
-          <div class="p-code-copyable">
-            <input class="p-code-copyable__input" aria-label="microstack.launch test" value="microstack.launch cirros --name test" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-          <p>
-            Your VM is up and running now. You should see a message like:
-          </p>
-          <p>Access your server with <code>ssh -i /home/ubuntu/.ssh/id_microstack cirros@10.20.20.3</code></p>
+      <div class="col-6 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
+        <ol class="p-stepped-list u-no-margin--left">
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Install Multipass for macOS</h3>
 
-          <h3>
-            Try a different version, or a beta, or a daily build
-          </h3>
-          <p>
-            Snaps are published in <a class="p-link--external" href="https://snapcraft.io/docs/channels">channels</a> which are made up of a track (or major version), and an expected level of stability. Try <code>snap info microstack</code> to see what versions are currently published. You can run
-          </p>
-          <div class="p-code-copyable">
-            <input class="p-code-copyable__input" aria-label="snap refresh --channel=latest/beta microstack" value="sudo snap refresh --channel=latest/beta microstack" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-          <p>
-            or
-          </p>
-          <div class="p-code-copyable">
-            <input class="p-code-copyable__input" aria-label="snap refresh --channel=1.11/stable microstack" value="sudo snap refresh --channel=1.11/stable microstack" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-          <p>
-            to get the required version.
-          </p>
-          <p>
-            For more information refer to the <a class="p-link--external" href="https://opendev.org/x/microstack/src/branch/master/README.md">MicroStack documentation</a> or <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/microstack-get-started#0">Get started with MicroStack tutorial</a>.
-          </p>
-        </div>
+            <p class="p-stepped-list__content u-stepped-list-margin">
+              <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download"
+                data-os="mac">
+                <span class="p-link--external">Download Multipass for macOS</span>
+              </a>
+            </p>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Start a multipass vm</h3>
+
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
+                value="multipass launch --name microkstack-vm --mem 8G --disk 40G" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Install the MicroStack snap on that multipass vm</h3>
+
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
+                value="multipass exec microkstack-vm -- sudo snap install microstack --classic --edge"
+                readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+
+            <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a
+                href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
+
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic"
+                value="sudo microstack.init --auto" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+          </li>
+        </ol>
+        <p>
+          That’s it! Your OpenStack is ready.
+        </p>
       </div>
-    </section>
-  </main>
+    </div>
+  </section>
+</main>
+
+<script defer src="/js/tabs.js"></script>

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,0 +1,60 @@
+function setupTabs() {
+  var tabs = document.querySelectorAll('.js-tab');
+
+  for (var i = 0; i < tabs.length; i += 1) {
+    var tab = tabs[i];
+    var tabSelector = tab.getAttribute('href');
+    var tabContent = document.querySelector(tabSelector);
+
+    if (tabContent) {
+      tab.setAttribute('aria-selected', 'false');
+      tabContent.classList.add('u-hide');
+
+      tab.addEventListener('click', function(e) {
+        e.preventDefault();
+        toggleTab(e.currentTarget);
+      });
+    }
+  }
+
+  function toggleTab(tab) {
+    var tabSelector = tab.getAttribute('href');
+    var tabContent = document.querySelector(tabSelector);
+  
+    for (var i = 0; i < tabs.length; i += 1) {
+      if (tabs[i] !== tab) {
+        var otherTabSelector = tabs[i].getAttribute('href');
+        var otherTabContent = document.querySelector(otherTabSelector);
+        
+        tabs[i].setAttribute('aria-selected', 'false');
+        tabs[i].classList.remove('active');
+        otherTabContent.classList.add('u-hide');
+      }
+    }
+  
+    tab.setAttribute('aria-selected', 'true');
+    tab.classList.toggle('active');
+    tabContent.classList.toggle('u-hide');
+  
+    if (tab.classList.contains('active')) {
+      var breakpoint = 620;
+      var yOffset = 200;
+      var rect = tabContent.getBoundingClientRect();
+      var inView = ((window.innerHeight - yOffset) > rect.top);
+      var scrollTarget = window.scrollY + yOffset;
+  
+      if (window.innerWidth <= breakpoint) {
+        scrollTarget = (pageYOffset + rect.top) - 10;
+      }
+
+      if (!inView) {
+        window.scroll({
+          behavior: 'smooth',
+          top: scrollTarget
+        });
+      }
+    }
+  }
+}
+
+setupTabs();

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "clean": "rm -rf node_modules yarn-error.log css js *.log *.sqlite _site/ build/ .jekyll-metadata .bundle"
   },
   "dependencies": {
-    "@canonical/global-nav": "2.1.0",
+    "@canonical/global-nav": "^2.2.1",
     "autoprefixer": "9.6.0",
     "node-sass": "4.12.0",
     "postcss-cli": "6.1.2",
     "sass-lint": "1.13.1",
-    "vanilla-framework": "2.3.0",
+    "vanilla-framework": "2.4.1",
     "watch-cli": "0.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,11 @@
 # yarn lockfile v1
 
 
-"@canonical/global-nav@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.1.0.tgz#67b6a499a39ff8135e15fcc6a275cd1e29b504fa"
+"@canonical/global-nav@^2.2.1":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.3.0.tgz#8a72aa4c82fb61a067454e1102350112ae8d5ba8"
+  dependencies:
+    vanilla-framework "2.4.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -2887,9 +2889,13 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.3.0.tgz#420925e905ce451273bc54c8e5792f58fdd0ddf4"
+vanilla-framework@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.0.tgz#95fd15738ce72cbb30bb667ba255cc7e9ae3f13d"
+
+vanilla-framework@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.1.tgz#36ef374e90b8457a07e55cf33be1bcfd07092c84"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Add `Get started` button to hero
- Add tabs for Linux, Windows and macOS installation steps
- Move tips to docs
- Upgrade to vanilla 2.4.1
- Upgrade `global-nav` to 2.2.1

## QA

- download this branch
- run the site https://0.0.0.0:8039 and https://0.0.0.0:8039/docs/pro-tips
- compare to [design](https://github.com/canonical-web-and-design/web-squad/issues/1982)

## Issue

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1983