### PR TITLE
Add copy doc to site and fixed up text on homepage

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -54,21 +54,17 @@
   <script defer src="/js/osselector.js"></script>
 
   <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">
-
   <meta name="theme-color" content="#E95420">
   <meta name="twitter:account_id" content="4503599627481511">
   <meta name="twitter:site" content="@ubuntu">
   <meta property="og:type" content="website">
   <meta property="og:url" content="http://microstack.run">
   <meta property="og:site_name" content="microstack.run">
-
-
   <meta name="twitter:title" content="{% if page.title %}{{ page.title }} | MicroStack{% else %}MicroStack - OpenStack in a snap{% endif %}">
   <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">
-
   <meta property="og:title" content="{% if page.title %}{{ page.title }} | MicroStack{% else %}MicroStack - OpenStack in a snap{% endif %}">
   <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">
-
+  <meta name="copydoc" content="{{ page.meta_copydoc }}">
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/index.html
+++ b/index.html
@@ -1,9 +1,8 @@
 ---
 layout: base
-title: "Multi-node OpenStack"
-description: "MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation.
-Although made for developers, it is also suitable for edge, IoT and appliances."
-meta_copydoc: "https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit?usp=sharing"
+title: "MicroStack - OpenStack in a snap"
+description: "MicroStack is an upstream multi-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances."
+meta_copydoc: "https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit"
 ---
 <main id="main-content">
 
@@ -61,7 +60,7 @@ meta_copydoc: "https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_
           A full OpenStack in a single snap package. MicroStack is an upstream multi-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances. Grab MicroStack from the Snap Store and get your OpenStack running right away.
         </p>
         <p>
-          <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/microstack-get-started#0">Get started with MicroStack tutorial</a>
+          <a class="p-link--external" href="https://ubuntu.com/tutorials/microstack-get-started#1-overview">Get started with MicroStack tutorial</a>
         </p>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@ layout: base
 title: "Multi-node OpenStack"
 description: "MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation.
 Although made for developers, it is also suitable for edge, IoT and appliances."
+meta_copydoc: "https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit?usp=sharing"
 ---
 <main id="main-content">
 
@@ -57,14 +58,10 @@ Although made for developers, it is also suitable for edge, IoT and appliances."
     <div class="row">
       <div class="col-8">
         <p>
-          A full OpenStack in a single snap package! MicroStack is an upstream multi-node OpenStack deployment which can
-          run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and
-          appliances. Do not wait anymore - grab MicroStack from the Snap Store and get your OpenStack running right
-          away!
+          A full OpenStack in a single snap package. MicroStack is an upstream multi-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances. Grab MicroStack from the Snap Store and get your OpenStack running right away.
         </p>
         <p>
-          <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/microstack-get-started#0">Get started
-            with MicroStack tutorial</a>
+          <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/microstack-get-started#0">Get started with MicroStack tutorial</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Add copy doc to front-matter
- [Requested](https://github.com/canonical-web-and-design/ubuntu-copy-docs/issues/7) that this site is added to the google/firefox extensions
- Fixed minor text update found in the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the meta name="copydoc" has a copy doc in the value
- See that the page mirrors the [copydoc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit?usp=sharing)

