### PR TITLE
Disable renovate for ruby

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    "docker:disable",
     "schedule:monthly",
     "group:all"
   ],


### PR DESCRIPTION
## Done

Disable renovate to avoid upgrades to ruby 2.7.
