### PR TITLE
Add HR to buttom of docs layout

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -56,3 +56,5 @@ layout: base
   </main>
 
 </div>
+
+<hr>


### PR DESCRIPTION
## Done

Added an `<hr>` to the docs template to give a line between the content and the footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/docs
- See the line above the footer like on other pages
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #33 
