### PR TITLE
Move to use fixed multipass.run download links

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -50,7 +50,6 @@
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
 
   <script defer src="/js/copy-to-clipboard.js"></script>
-  <script defer src="/js/installversion.js"></script>
   <script defer src="/js/osselector.js"></script>
 
   <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@ meta_copydoc: "https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_
             <h3 class="p-stepped-list__title">Install Multipass for Windows</h3>
 
             <p class="p-stepped-list__content u-stepped-list-margin">
-              <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download"
+              <a href="https://multipass.run/download/windows" class="p-button--positive"
                 data-os="win-win">
                 Download Multipass for Windows
               </a>
@@ -269,7 +269,7 @@ meta_copydoc: "https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_
             <h3 class="p-stepped-list__title">Install Multipass for macOS</h3>
 
             <p class="p-stepped-list__content u-stepped-list-margin">
-              <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download"
+              <a href="https://multipass.run/download/macos" class="p-button--positive"
                 data-os="mac">
                 Download Multipass for macOS
               </a>


### PR DESCRIPTION
## Done

- Move to use fixed multipass.run download links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the multipass windows and macos downloads point to multipass.run/download/windows and macos

