### PR TITLE
Rework MicroStack docs to use Secure Clustering

### DIFF
--- a/templates/docs/docs.html
+++ b/templates/docs/docs.html
@@ -46,24 +46,26 @@ description: "How to install, run and configure microstack."
           To quickly configure networks and launch a vm, run
         </p>
         <div class="p-code-copyable">
-          <input class="p-code-copyable__input" value="sudo microstack.init" readonly="readonly">
+          <input class="p-code-copyable__input" value="sudo microstack init" readonly="readonly">
           <button class="p-code-copyable__action">Copy to clipboard</button>
         </div>
         <p>
           This will configure various Openstack databases. Then run:
         </p>
         <div class="p-code-copyable">
-          <input class="p-code-copyable__input" value="microstack.launch" readonly="readonly">
+          <input class="p-code-copyable__input" value="microstack launch" readonly="readonly">
           <button class="p-code-copyable__action">Copy to clipboard</button>
         </div>
         <p>
           This will launch an instance for you, and make it available to manage via the command line, or via the Horizon Dashboard.
         </p>
+        <p>In order to get a password for the admin user in Keystone use the following command:</p>
+        <pre><code>$ sudo snap get microstack config.credentials.keystone-password</code></pre>
         <p>
-          To access the Dashboard, visit <a href="http://10.20.20.1">10.20.20.1</a>in a web browser, and login with the following credentials:
+          To access the Dashboard, visit <a href="http://localhost">localhost</a>in a web browser, and login with the following credentials:
         </p>
         <pre><code>username: admin
-password: keystone</code></pre>
+password: <keystone-admin-password></code></pre>
           <p>
             To ssh into the instance, use the username &quot;cirros&quot; and the ssh key written to <code>~/.ssh/id_microstack</code>:
           </p>
@@ -75,7 +77,7 @@ password: keystone</code></pre>
             Where 'IP' is listed in the output of:
           </p>
           <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="microstack.launch" readonly="readonly">
+            <input class="p-code-copyable__input" value="microstack launch" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>
@@ -102,19 +104,13 @@ password: keystone</code></pre>
             <input class="p-code-copyable__input" value="microstack.openstack server list" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-          <p>
-            You can setup this command as an alias for <code>openstack</code> if you wish (removing the need for the <code>microstack.</code> prefix):
-          </p>
-          <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="sudo snap alias microstack.openstack openstack" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-          <p>
-            Alternatively you can access the Horizon OpenStack dashboard on <code>http://127.0.0.1</code> with the following credentials:
-          </p>
-          <pre><code>username: admin
-password: keystone</code></pre>
-          </div>
+        <p>In order to get a password for the admin user in Keystone use the following command:</p>
+        <pre><code>$ sudo snap get microstack config.credentials.keystone-password</code></pre>
+        <p>
+          To access the Dashboard, visit <a href="http://localhost">localhost</a>in a web browser, and login with the following credentials:
+        </p>
+        <pre><code>username: admin
+password: <keystone-admin-password></code></pre>
         </div>
         <div class="u-fixed-width">
           <hr class="p-separator" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,13 +59,13 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
       </div>
       <div class="col-4">
         <ul class="p-list--divided u-no-margin--bottom__medium">
-          <li class="p-list__item is-ticked">Neutron with OVS</li>
-          <li class="p-list__item is-ticked">Dashboard</li>
-          <li class="p-list__item is-ticked last-item">Metrics</li>
+          <li class="p-list__item is-ticked">Placement</li>
+          <li class="p-list__item is-ticked">Neutron with OVN</li>
+          <li class="p-list__item is-ticked">Cinder</li>
       </div>
       <div class="col-4">
         <ul class="p-list--divided">
-          <li class="p-list__item is-ticked">GPGPU bindings</li>
+          <li class="p-list__item is-ticked">Dashboard</li>
           <li class="p-list__item is-ticked">Clustering <small class="p-label--in-progress">BETA</small></li>
         </ul>
       </div>
@@ -200,7 +200,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
             <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="sudo microstack.init --auto" readonly="readonly">
+              <input class="p-code-copyable__input" value="sudo microstack init --auto --control" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </li>
@@ -208,7 +208,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
             <h3 class="p-stepped-list__title">Launch a VM</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="microstack.launch cirros --name test" readonly="readonly">
+              <input class="p-code-copyable__input" value="microstack launch cirros --name test" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
             <p>Your VM is up and running now. You should see a message like:</p>
@@ -253,7 +253,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
 
             <div class="p-code-copyable u-stepped-list-margin">
               <input class="p-code-copyable__input"
-                value="sudo microstack.init --auto" readonly="readonly">
+                value="sudo microstack.init --auto --control" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </li>
@@ -261,7 +261,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
             <h3 class="p-stepped-list__title">Launch a VM</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="microstack.launch cirros --name test" readonly="readonly">
+              <input class="p-code-copyable__input" value="microstack launch cirros --name test" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
             <p>Your VM is up and running now. You should see a message like:</p>
@@ -305,7 +305,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
             <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="sudo microstack.init --auto" readonly="readonly">
+              <input class="p-code-copyable__input" value="sudo microstack init --auto --control" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </li>
@@ -313,7 +313,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
             <h3 class="p-stepped-list__title">Launch a VM</h3>
 
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="microstack.launch cirros --name test" readonly="readonly">
+              <input class="p-code-copyable__input" value="microstack launch cirros --name test" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
             <p>Your VM is up and running now. You should see a message like:</p>


### PR DESCRIPTION
As of revision 215 in the store, MicroStack contains the Secure
Clustering feature which also introduces the "microstack" command
with {init, launch, add-compute} subcommands and makes the node
role a mandatory CLI argument to be specified when --auto is used.
https://review.opendev.org/#/c/757658/

Passwords are now randomly generated to avoid insecure practices:
https://review.opendev.org/#/c/756567/

This change addresses the above modifications.

Metrics and GPGPU sections are removed since they have not been
validated after an upgrade to Focal/Ussuri/OVN (and have not
had any auto test coverage prior to that).

https://review.opendev.org/#/c/738242/

Metrics specifically were added as an experimental contribution
which has not received proper validation and testing.