### PR TITLE
Rebuild MicroStack home page

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PORT=8039
 DEVEL=True
-FLASK_DEBUG=false
+FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key

--- a/static/js/typer.js
+++ b/static/js/typer.js
@@ -1,0 +1,141 @@
+// Copied from this project:
+// https://steven.codes/typerjs/docs/index.html
+
+var Typer = function (element) {
+  this.element = element;
+  var delim = element.dataset.delim || ",";
+  var words = element.dataset.words || "override these,sample typing";
+  this.words = words.split(delim).filter((v) => v); // non empty words
+  this.delay = element.dataset.delay || 200;
+  this.loop = element.dataset.loop || "true";
+  if (this.loop === "false") {
+    this.loop = 1;
+  }
+  this.deleteDelay =
+    element.dataset.deletedelay || element.dataset.deleteDelay || 800;
+
+  this.progress = { word: 0, char: 0, building: true, looped: 0 };
+  this.typing = true;
+
+  var colors = element.dataset.colors || "black";
+  this.colors = colors.split(",");
+  this.element.style.color = this.colors[0];
+  this.colorIndex = 0;
+
+  this.doTyping();
+};
+
+Typer.prototype.start = function () {
+  if (!this.typing) {
+    this.typing = true;
+    this.doTyping();
+  }
+};
+Typer.prototype.stop = function () {
+  this.typing = false;
+};
+Typer.prototype.doTyping = function () {
+  var e = this.element;
+  var p = this.progress;
+  var w = p.word;
+  var c = p.char;
+  var currentDisplay = [...this.words[w]].slice(0, c).join("");
+  var atWordEnd;
+  if (this.cursor) {
+    this.cursor.element.style.opacity = "1";
+    this.cursor.on = true;
+    clearInterval(this.cursor.interval);
+    this.cursor.interval = setInterval(
+      () => this.cursor.updateBlinkState(),
+      400
+    );
+  }
+
+  e.innerHTML = currentDisplay;
+
+  if (p.building) {
+    atWordEnd = p.char === this.words[w].length;
+    if (atWordEnd) {
+      p.building = false;
+    } else {
+      p.char += 1;
+    }
+  } else {
+    if (p.char === 0) {
+      p.building = true;
+      p.word = (p.word + 1) % this.words.length;
+      this.colorIndex = (this.colorIndex + 1) % this.colors.length;
+      this.element.style.color = this.colors[this.colorIndex];
+    } else {
+      p.char -= 1;
+    }
+  }
+
+  if (p.word === this.words.length - 1) {
+    p.looped += 1;
+  }
+
+  if (!p.building && this.loop <= p.looped) {
+    this.typing = false;
+  }
+
+  var randomDelay = this.delay;
+  if (p.building) {
+    randomDelay =
+      parseInt(this.delay) + parseInt(Math.random() * 2 * this.delay);
+  }
+
+  if (this.words[w][c] === "") {
+    randomDelay = 0;
+  }
+
+  setTimeout(
+    () => {
+      if (this.typing) {
+        this.doTyping();
+      }
+    },
+    atWordEnd ? this.deleteDelay : randomDelay
+  );
+};
+
+var Cursor = function (element) {
+  this.element = element;
+  this.cursorDisplay =
+    element.dataset.cursordisplay || element.dataset.cursorDisplay || "_";
+  element.innerHTML = this.cursorDisplay;
+  this.on = true;
+  element.style.transition = "all 0.1s";
+  this.interval = setInterval(() => this.updateBlinkState(), 400);
+};
+Cursor.prototype.updateBlinkState = function () {
+  if (this.on) {
+    this.element.style.opacity = "0";
+    this.on = false;
+  } else {
+    this.element.style.opacity = "1";
+    this.on = true;
+  }
+};
+
+function TyperSetup() {
+  var typers = {};
+  for (let e of document.getElementsByClassName("typer")) {
+    typers[e.id] = new Typer(e);
+  }
+  for (let e of document.getElementsByClassName("typer-stop")) {
+    let owner = typers[e.dataset.owner];
+    e.onclick = () => owner.stop();
+  }
+  for (let e of document.getElementsByClassName("typer-start")) {
+    let owner = typers[e.dataset.owner];
+    e.onclick = () => owner.start();
+  }
+  for (let e of document.getElementsByClassName("cursor")) {
+    let t = new Cursor(e);
+    t.owner = typers[e.dataset.owner];
+    t.owner.cursor = t;
+  }
+}
+
+TyperSetup();

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,24 +24,23 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
         </p>
       </div>
       <div class="col-5 u-align--center u-hide--small u-embedded-media">
-        <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/v9KI2BAF5QU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/fNk7AfxNggc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
-    </div>
   </section>
   <section class="p-strip">
     <div class="row">
       <div class="p-notification--caution">
         <p class="p-notification__response">
-          <strong>Note:</strong> MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>. For information about commercial support for MicroStack, contact <a class="p-link--external" href="https://canonical.com">Canonical</a>.
+          <strong>Note:</strong> MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>. For information about commercial support for MicroStack, <a class="p-link--external" href="https://ubuntu.com/openstack/contact-us">contact Canonical</a>.
         </p>
       </div>
     </div>
     <div class="row">
       <div class="col-8" style="margin-top: 2rem;">
         <h2>Straightforward installation</h2>
-        <h4>Fully functional OpenStack in 2 commands and ~20 minutes.</h4>
+        <h3 class="p-heading--4">Fully functional OpenStack in 2 commands and ~20 minutes.</h3>
       </div>
-      <pre class="p-heading--two"><code><span style="display: block;" class="typer" id="main" data-words="$ sudo snap install microstack --beta --devmode, $ sudo microstack init --auto --control" data-delay="50" data-deleteDelay="5000" data-colors="#111111"></span></code></pre>
+      <pre class="p-heading--two"><code>$ sudo <span class="typer" id="main" data-words="snap install microstack --beta --devmode,microstack init --auto --control" data-delay="50" data-deleteDelay="5000" data-colors="#111111"></span></code></pre>
       <p>
         <a class="p-link--external" href="https://ubuntu.com/tutorials/microstack-get-started#1-overview">MicroStack tutorial</a>
       </p>
@@ -53,7 +52,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
         <h3 class="u-align--center">7 contributors</h3>
       </div>
       <div class="col-4 p-divider__block u-vertically-center">
-        <h3 class="u-align--center" >~250 commits</h3>
+        <h3 class="u-align--center">~250 commits</h3>
       </div>
       <div class="col-4 p-divider__block u-vertically-center">
         <h3 class="u-align--center" style="margin-left: 1.5rem; margin-right: 1.5rem;">~1,500 active installations</h3>
@@ -64,7 +63,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
       <div class="row">
         <div class="col-6">
           <h2>OpenStack for the edge</h2>
-          <h4>Comprehensive cloud platform for distributed low-latency applications</h4>
+          <h3 class="p-heading--4">Comprehensive cloud platform for distributed low-latency applications</h3>
           <p>MicroStack answers the needs of edge computing, providing a secure, reliable and scalable cloud platform with minimal footprint and simplified lifecycle management capabilities.</p>
           <p>All to meet the requirements of the most demanding applications in telecom, industrial, automotive and other market sectors that need edge infrastructure.</p>
           <p>
@@ -82,7 +81,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
         </div>
         <div class="col-6">
           <h2>OpenStack for micro clouds</h2>
-          <h4>Small-scale cost-efficient private cloud infrastructure</h4>
+          <h3 class="p-heading--4">Small-scale cost-efficient private cloud infrastructure</h3>
           <p>OpenStack private cloud implementation used to be challenging due to the complexity of OpenStack and its scale. This is no longer the case.</p>
           <p>MicroStack enables enterprises to quickly deploy cost-efficient private cloud infrastructure from single-node installations to micro cloud clusters.</p>
           <p>
@@ -94,7 +93,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
       <div class="row">
         <div class="col-6">
           <h2>OpenStack for developers</h2>
-          <h4>On your workstation, in your CI/CD environment</h4>
+          <h3 class="p-heading--4">On your workstation, in your CI/CD environment</h3>
           <p>Designed for devices with minimal hardware resources, MicroStack is perfectly suitable for developer workstations and CI/CD environments.</p>
           <p>If you are using OpenStack in production, MicroStack effectively connects the dots between your cloud operations team and developers. </p>
           <p>
@@ -155,32 +154,30 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
     <div class="row">
       <div class="col-7">
         <h2>OpenStack on rails</h2>
-        <h4>OpenStack has tens of components and options. Not everyone needs this complexity.</h4>
-       </div>
-      <div class="col-6">
+        <h3 class="p-heading--4">OpenStack has tens of components and options. Not everyone needs this complexity.</h3>
         <p>MicroStack includes core OpenStack services and the most popular compute, network and storage options. This eliminates the OpenStack complexity and provides an “on rails” experience.</p>
+       </div>
+    </div>  
+    <div class="row u-equal-height">
+      <div class="col-3">
+        <ul class="p-list u-no-margin--bottom__medium">
+          <li class="p-list__item is-ticked" style="border-bottom: 0">Keystone</li>
+          <li class="p-list__item is-ticked">Horizon</li>
+          <li class="p-list__item is-ticked last-item">Glance</li>
+        </ul>
       </div>
-      <div class="col-8 u-equal-height">
-        <div class="col-3">
-          <ul class="p-list u-no-margin--bottom__medium">
-            <li class="p-list__item is-ticked" style="border-bottom: 0">Keystone</li>
-            <li class="p-list__item is-ticked">Horizon</li>
-            <li class="p-list__item is-ticked last-item">Glance</li>
-          </ul>
-        </div>
-        <div class="col-3">
-          <ul class="p-list u-no-margin--bottom__medium">
-            <li class="p-list__item is-ticked">Nova</li>
-            <li class="p-list__item is-ticked">Neutron</li>
-            <li class="p-list__item is-ticked last-item">Cinder</li>
-        </div>
-        <div class="col-3">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">KVM</li>
-            <li class="p-list__item is-ticked">OVN</li>
-            <li class="p-list__item is-ticked last-item">Local storage</li>
-          </ul>
-        </div>
+      <div class="col-3">
+        <ul class="p-list u-no-margin--bottom__medium">
+          <li class="p-list__item is-ticked">Nova</li>
+          <li class="p-list__item is-ticked">Neutron</li>
+          <li class="p-list__item is-ticked last-item">Cinder</li>
+      </div>
+      <div class="col-3">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">KVM</li>
+          <li class="p-list__item is-ticked">OVN</li>
+          <li class="p-list__item is-ticked last-item">Local storage</li>
+        </ul>
       </div>
     </div>
   </section>
@@ -218,8 +215,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
               <input class="p-code-copyable__input" value="sudo snap install microstack --beta --devmode" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
-            <p class="p-stepped-list__content u-stepped-list-margin"><code>snap</code> command not found? <a
-                href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Install snapd</a>.</p>
+            <p class="p-stepped-list__content u-stepped-list-margin"><code>snap</code> command not found? <a href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Install snapd</a>.</p>
           </li>
           <li class="p-stepped-list__item">
             <h3 class="p-stepped-list__title">Set up MicroStack</h3>
@@ -242,7 +238,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
           That’s it! Your micro cloud is ready.
         </p>
       </div>
-      <div class="col-8 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
+      <div class="col-9 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
         <ol class="p-stepped-list u-no-margin--left">
           <li class="p-stepped-list__item">
             <h3 class="p-stepped-list__title">Install Multipass</h3>
@@ -287,7 +283,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
           That’s it! Your micro cloud is ready.
         </p>
       </div>
-      <div class="col-8 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
+      <div class="col-9 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
         <ol class="p-stepped-list u-no-margin--left">
           <li class="p-stepped-list__item">
             <h3 class="p-stepped-list__title">Install Multipass</h3>
@@ -338,7 +334,7 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
     <div class="row u-vertically-center">
       <div class="col-6">
         <h2>The team behind MicroStack</h2>
-        <p>MicroStack is maintained by the <a class="p-link--external" href="https://ubuntu.com/openstack">OpenStack team at Canonical</a>. We provide OpenStack packages on Ubuntu and have two OpenStack distributions of our own. MicroStack is an on-rails, opinionated OpenStack for the edge, micro clouds and developers. <a class="p-link--external" href="https://ubuntu.com/openstack/features">Charmed OpenStack</a> is a composable enterprise OpenStack for large scale deployments in data centres.</p>
+        <p>MicroStack is maintained by the <a class="p-link--external" href="https://ubuntu.com/openstack">OpenStack team at Canonical</a>. We provide OpenStack packages on Ubuntu and have two OpenStack distributions of our own. MicroStack is an on-rails, opinionated OpenStack for the edge, micro clouds and developers. <a class="p-link--external" href="https://ubuntu.com/openstack/features">Charmed OpenStack</a> is a composable enterprise OpenStack for large scale deployments in data centres. MicroStack was built by the dedicated OpenStack team at Canonical for the developer community. We also make the Charmed OpenStack for multi-cloud scalable clusters. Please contact us if you have any questions. </p>
       </div>
       <div class="col-5 u-hide--small u-align--center">
         <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="Canonical" style="width : 160px; height:160px">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,8 +1,8 @@
 {% extends 'base_layout.html' %}
-{% block title %}MicroStack - OpenStack in a snap{% endblock %}
+{% block title %}OpenStack for the edge, micro clouds and developers{% endblock %}
 
 {% block description %}
-MicroStack is an upstream multi-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.
+MicroStack is a micro cloud solution based on OpenStack, designed for the edge and small-scale private cloud deployments, that can be installed and maintained with a minimal effort.
 {% endblock %}
 
 {% block meta_copydoc %}
@@ -14,192 +14,215 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
 <script defer src="{{ versioned_static('js/osselector.js') }}"></script>
 
 <main id="main-content">
-
-  <section class="p-strip--header is-dark">
+  <section class="p-strip--suru is-dark">
     <div class="row u-vertically-center u-equal-height">
-      <div class="col-8">
-        <h1>
-          Multi-node OpenStack for workstations and edge / IoT
-        </h1>
-        <p class="p-heading--four u-sv3">
-          Install and run OpenStack on Linux in minutes. Made for developers and great for edge, IoT, and appliances.
-        </p>
+      <div class="col-7">
+        <h1> OpenStack for the edge, <br/> micro clouds and developers </h1>
+        <p class="p-heading--four"> The most straightforward OpenStack ever. </p>
         <p>
-          <a class="p-button--positive is-inline" href="#get-started">Get started</a><span style="padding-left: .5rem;">for Linux, Windows or macOS</span>
+          <a class="p-button--positive" href="#get-started">Try MicroStack</a> &nbsp;and break the ice with OpenStack today
         </p>
       </div>
-      <div class="col-4 u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/5a6af817-OpenStack-Logo-Vertical-white.svg" width="250"
-          alt="" />
+      <div class="col-5 u-align--center u-hide--small u-embedded-media">
+        <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/v9KI2BAF5QU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </section>
-
   <section class="p-strip">
     <div class="row">
       <div class="p-notification--caution">
         <p class="p-notification__response">
-          <span class="p-notification__status">Note:</span> MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>.
+          <strong>Note:</strong> MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>. For information about commercial support for MicroStack, contact <a class="p-link--external" href="https://canonical.com">Canonical</a>.
         </p>
       </div>
     </div>
     <div class="row">
-      <div class="col-8">
-        <h2>OpenStack in a snap</h2>
-        <h4>Zero-ops OpenStack on just about any Linux box.</h4>
+      <div class="col-8" style="margin-top: 2rem;">
+        <h2>Straightforward installation</h2>
+        <h4>Fully functional OpenStack in 2 commands and ~20 minutes.</h4>
       </div>
+      <pre class="p-heading--two"><code><span style="display: block;" class="typer" id="main" data-words="$ sudo snap install microstack --beta --devmode, $ sudo microstack init --auto --control" data-delay="50" data-deleteDelay="5000" data-colors="#111111"></span></code></pre>
+      <p>
+        <a class="p-link--external" href="https://ubuntu.com/tutorials/microstack-get-started#1-overview">MicroStack tutorial</a>
+      </p>
     </div>
-    <div class="row u-equal-height">
-      <div class="col-4">
-        <ul class="p-list--divided u-no-margin--bottom__medium">
-          <li class="p-list__item is-ticked">Keystone</li>
-          <li class="p-list__item is-ticked">Glance</li>
-          <li class="p-list__item is-ticked last-item">Nova</li>
-        </ul>
-      </div>
-      <div class="col-4">
-        <ul class="p-list--divided u-no-margin--bottom__medium">
-          <li class="p-list__item is-ticked">Neutron with OVN</li>
-          <li class="p-list__item is-ticked">Cinder</li>
-          <li class="p-list__item is-ticked last-item">Dashboard</li>
-      </div>
-      <div class="col-4">
-        <ul class="p-list--divided">
-          <li class="p-list__item is-ticked">Metrics</li>
-          <li class="p-list__item is-ticked">GPGPU bindings</li>
-          <li class="p-list__item is-ticked last-item">Clustering</li>
-        </ul>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-8">
-        <p>
-          A full OpenStack in a single snap package. MicroStack is an upstream multi-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances. Grab MicroStack from the Snap Store and get your OpenStack running right away.
-        </p>
-        <p>
-          <a class="p-link--external" href="https://ubuntu.com/tutorials/microstack-get-started#1-overview">Get started with MicroStack tutorial</a>
-        </p>
-      </div>
-    </div>
-
   </section>
-
+  <section class="p-strip--light">
+    <div class="row u-equal-height">
+      <div class="col-4 p-divider__block u-vertically-center">
+        <h3 class="u-align--center">7 contributors</h3>
+      </div>
+      <div class="col-4 p-divider__block u-vertically-center">
+        <h3 class="u-align--center" >~250 commits</h3>
+      </div>
+      <div class="col-4 p-divider__block u-vertically-center">
+        <h3 class="u-align--center" style="margin-left: 1.5rem; margin-right: 1.5rem;">~1,500 active installations</h3>
+      </div>
+    </div>
+  </section>
+  <section class="p-strip">
+      <div class="row">
+        <div class="col-6">
+          <h2>OpenStack for the edge</h2>
+          <h4>Comprehensive cloud platform for distributed low-latency applications</h4>
+          <p>MicroStack answers the needs of edge computing, providing a secure, reliable and scalable cloud platform with minimal footprint and simplified lifecycle management capabilities.</p>
+          <p>All to meet the requirements of the most demanding applications in telecom, industrial, automotive and other market sectors that need edge infrastructure.</p>
+          <p>
+            <a href="https://ubuntu.com/blog/edge-computing-is-dead-long-live-micro-clouds-and-iot-gateways" class="p-link--external">Read a blog about Canonical's edge strategy</a>
+          </p>
+        </div>
+        <div class="col-6 u-align--center u-vertically-center">
+          <img src="https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg" class="u-hide--small" style="height: 225px; width: 394px;" alt="openstack cloud outlines">
+        </div>
+        <hr class="p-separator" />
+      </div>
+      <div class="row">
+        <div class="col-6 u-align--center u-vertically-center">
+          <img src="https://assets.ubuntu.com/v1/e2bf84de-edge-cluster.svg" class="u-hide--small" style="height: 225px; width: 234px;" alt="openstack cloud white">
+        </div>
+        <div class="col-6">
+          <h2>OpenStack for micro clouds</h2>
+          <h4>Small-scale cost-efficient private cloud infrastructure</h4>
+          <p>OpenStack private cloud implementation used to be challenging due to the complexity of OpenStack and its scale. This is no longer the case.</p>
+          <p>MicroStack enables enterprises to quickly deploy cost-efficient private cloud infrastructure from single-node installations to micro cloud clusters.</p>
+          <p>
+            <a href="https://ubuntu.com/openstack/features" class="p-link--external">For large-scale deployments try Charmed OpenStack</a>
+          </p>
+        </div>
+        <hr class="p-separator" />
+      </div>
+      <div class="row">
+        <div class="col-6">
+          <h2>OpenStack for developers</h2>
+          <h4>On your workstation, in your CI/CD environment</h4>
+          <p>Designed for devices with minimal hardware resources, MicroStack is perfectly suitable for developer workstations and CI/CD environments.</p>
+          <p>If you are using OpenStack in production, MicroStack effectively connects the dots between your cloud operations team and developers. </p>
+          <p>
+            <a href="https://www.openstack.org/videos/summits/virtual/OpenStack-on-rails-meet-MicroStack" class="p-link--external">Watch MicroStack in action</a>
+          </p>
+        </div>
+        <div class="col-6 u-align--center u-vertically-center">
+          <img src="https://assets.ubuntu.com/v1/d1782e3a-dev-at-laptop.svg" class="u-hide--small" style="height: 225px; width: 208px;" alt="dev at laptop">
+        </div>
+      </div>
+  </section>
+  <section class="p-strip--suru is-dark">
+    <div class="row">
+      <div class="col-6">
+        <h2>Share your use case</h2>
+        <p>Web applications, AI/ML or maybe telco NFV? What are you using MicroStack for? Do not hesitate and share your use case, and benefit from the community collaboration and help.</p>
+        <p>
+          <a href="https://discourse.charmhub.io/search?q=microstack" class="p-link--external" style="color:#fff">Share your use case</a>  
+        </p>
+      </div>
+    </div>
+  </section>
+  <section class="p-strip is-deep">
+    <div class="row">
+      <div class="col-6">
+        <h2 class="u-sv3">Open source cloud</h2>
+        <p>MicroStack is a pure upstream OpenStack distribution which effectively decreases virtualisation costs. It is a reasonable alternative to VMware clusters, Microsoft Hyper-V, Citrix Hypervisor and Proxmox Virtualization Environment.</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6 p-card">
+        <h3>OpenStack community project</h3>
+        <hr class="u-sv1">
+        <p>MicroStack is an Openstack community project with optional commercial support available from Canonical. It benefits from the 10 year maturity of OpenStack, its stability and community collaboration.</p>
+        <p><a href="https://discourse.charmhub.io/search?q=microstack" class="p-link--external">Join the community</a></p>
+      </div>
+      <div class="col-6 p-card">
+        <h3>All-in one OpenStack</h3>
+        <hr class="u-sv1">
+        <p>MicroStack is an OpenStack in a snap. This means that all OpenStack components and their dependencies are packaged together inside of a single image that runs in isolation, ensuring high-level security.</p>
+        <p><a href="https://snapcraft.io/microstack" class="p-link--external">Learn more about snaps</a></p>
+      </div>
+      <div class="col-6 p-card">
+        <h3>Single-node OpenStack</h3>
+        <hr class="u-sv1">
+        <p>Single-node installation is usually the first step to try OpenStack. MicroStack supports this use case, providing the ability to deploy fully functional OpenStack on a single machine with just 2 commands.</p>
+        <p><a href="/docs/single-node">Read single-node installation instructions&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-6 p-card">
+        <h3>Multi-node OpenStack</h3>
+        <hr class="u-sv1">
+        <p>In order to meet the demand for multi-node OpenStack deployments, MicroStack also supports clustering with one node acting as a cloud controller and other nodes acting as hypervisors.</p>
+        <p><a href="/docs/multi-node">Read multi-node installation instructions&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </section>
   <section class="p-strip--light">
     <div class="row">
-      <h2>Reliable, small, ready to go</h2>
-    </div>
-    <div class="row">
-      <ul class="p-matrix u-clearfix">
-        <li class="p-matrix__item">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Fast install</h3>
-            <div class="p-matrix__desc">
-              <p>
-                Get a full OpenStack system running in minutes.
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Secure</h3>
-            <div class="p-matrix__desc">
-              <p>
-                Runs safely on your laptop with state of the art isolation.
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Upstream</h3>
-            <div class="p-matrix__desc">
-              <p>
-                Pure upstream OpenStack delivered to your laptop.
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Complete</h3>
-            <div class="p-matrix__desc">
-              <p>
-                Includes all key OpenStack components: Keystone, Nova, Neutron, Glance, and Cinder.
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Featureful</h3>
-            <div class="p-matrix__desc">
-              <p>
-                All the cool things you probably want to try on a small, standard OpenStack are all built-in.
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Small</h3>
-            <div class="p-matrix__desc">
-              <p>
-                Use MicroStack in your CI/CD pipelines and get on with your day without headaches.
-              </p>
-            </div>
-          </div>
-        </li>
-      </ul>
+      <div class="col-7">
+        <h2>OpenStack on rails</h2>
+        <h4>OpenStack has tens of components and options. Not everyone needs this complexity.</h4>
+       </div>
+      <div class="col-6">
+        <p>MicroStack includes core OpenStack services and the most popular compute, network and storage options. This eliminates the OpenStack complexity and provides an “on rails” experience.</p>
+      </div>
+      <div class="col-8 u-equal-height">
+        <div class="col-3">
+          <ul class="p-list u-no-margin--bottom__medium">
+            <li class="p-list__item is-ticked" style="border-bottom: 0">Keystone</li>
+            <li class="p-list__item is-ticked">Horizon</li>
+            <li class="p-list__item is-ticked last-item">Glance</li>
+          </ul>
+        </div>
+        <div class="col-3">
+          <ul class="p-list u-no-margin--bottom__medium">
+            <li class="p-list__item is-ticked">Nova</li>
+            <li class="p-list__item is-ticked">Neutron</li>
+            <li class="p-list__item is-ticked last-item">Cinder</li>
+        </div>
+        <div class="col-3">
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">KVM</li>
+            <li class="p-list__item is-ticked">OVN</li>
+            <li class="p-list__item is-ticked last-item">Local storage</li>
+          </ul>
+        </div>
+      </div>
     </div>
   </section>
-
   <section class="p-strip" id="get-started" role="tablist">
     <div class="u-fixed-width">
-      <h2>Get started with MicroStack</h2>
+      <h2>Try MicroStack</h2>
       <div class="p-notification--information">
         <p class="p-notification__response">
-          MicroStack requires at least 8 GB RAM and a multi-core processor.
+          MicroStack requires at least a multi-core CPU, 8 GB of RAM and 100 GB of storage.
         </p>
       </div>
-      <h3>What OS are you developing on?</h3>
+      <h3>What OS are you on?</h3>
     </div>
-
     <div class="row u-equal-height u-sv3">
       <a id="tab-one" href="#tab-one__content"
         class="col-small-2 col-medium-2 col-4 p-card p-tab u-align--center u-vertically-center js-tab" role="tab">
         <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg" style="height: 90px; margin-top: 1rem;" alt="">
         <p class="p-heading--four" class="p-heading--five p-tab__title">Linux</p>
       </a>
-
       <a id="tab-two" href="#tab-two__content"
         class="col-small-2 col-medium-2 col-4 p-card p-tab u-align--center u-vertically-center js-tab" role="tab">
         <img src="https://assets.ubuntu.com/v1/11ecbd2d-2018-logo-windows.svg" style="height: 145px;" alt="Windows">
       </a>
-
       <a id="tab-three" href="#tab-three__content"
         class="col-small-2 col-medium-2 col-4 p-card p-tab u-align--center u-vertically-center js-tab" role="tab">
         <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" style="height: 145px;" alt="macOS">
       </a>
     </div>
-
     <div class="row">
       <div class="col-6 js-tab__content" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one">
         <ol class="p-stepped-list u-no-margin--left">
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Install the microstack snap</h3>
-
+            <h3 class="p-stepped-list__title">Install MicroStack</h3>
             <div class="p-code-copyable u-stepped-list-margin">
               <input class="p-code-copyable__input" value="sudo snap install microstack --beta --devmode" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
-
-            <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a
-                href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
+            <p class="p-stepped-list__content u-stepped-list-margin"><code>snap</code> command not found? <a
+                href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Install snapd</a>.</p>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
-
+            <h3 class="p-stepped-list__title">Set up MicroStack</h3>
             <div class="p-code-copyable u-stepped-list-margin">
               <input class="p-code-copyable__input" value="sudo microstack init --auto --control" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -207,7 +230,6 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
           </li>
           <li class="p-stepped-list__item">
             <h3 class="p-stepped-list__title">Launch a VM</h3>
-
             <div class="p-code-copyable u-stepped-list-margin">
               <input class="p-code-copyable__input" value="microstack launch cirros --name test" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -217,94 +239,35 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
           </li>
         </ol>
         <p>
-          That’s it! Your OpenStack is ready.
+          That’s it! Your micro cloud is ready.
         </p>
       </div>
-      <div class="col-6 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
+      <div class="col-8 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
         <ol class="p-stepped-list u-no-margin--left">
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Install Multipass for Windows</h3>
-
+            <h3 class="p-stepped-list__title">Install Multipass</h3>
             <p class="p-stepped-list__content u-stepped-list-margin">
-              <a href="https://multipass.run/download/windows" class="p-button--positive"
-                data-os="win-win">
-                Download Multipass for Windows
+              <a href="https://multipass.run/download/windows" class="p-button--positive" data-os="win-win">
+                Download
               </a>
             </p>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Start a Multipass VM</h3>
-
+            <h3 class="p-stepped-list__title">Get a VM with Linux</h3>
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="multipass launch --name microstack-vm --mem 8G --disk 40G" readonly="readonly">
+              <input class="p-code-copyable__input" value="multipass launch --name microstack-vm --mem 8G --disk 100G" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Install the MicroStack snap on that Multipass VM</h3>
-
+            <h3 class="p-stepped-list__title">Install MicroStack</h3>
             <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="multipass exec microstack-vm -- sudo snap install microstack --beta --devmode"
-                readonly="readonly">
+              <input class="p-code-copyable__input" value="multipass exec microstack-vm -- sudo snap install microstack --beta --devmode" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
-
-            <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input"
-                value="sudo microstack init --auto --control" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-          </li>
-          <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Launch a VM</h3>
-
-            <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="microstack launch cirros --name test" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-            <p>Your VM is up and running now. You should see a message like:</p>
-            <p>Access your server with <code class="highlighter-rouge">ssh -i /home/ubuntu/snap/microstack/common/.ssh/id_microstack cirros@10.20.20.3</code></p>
-          </li>
-        </ol>
-        <p>
-          That’s it! Your OpenStack is ready.
-        </p>
-      </div>
-      <div class="col-6 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
-        <ol class="p-stepped-list u-no-margin--left">
-          <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Install Multipass for macOS</h3>
-
-            <p class="p-stepped-list__content u-stepped-list-margin">
-              <a href="https://multipass.run/download/macos" class="p-button--positive"
-                data-os="mac">
-                Download Multipass for macOS
-              </a>
-            </p>
-          </li>
-          <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Start a Multipass VM</h3>
-
-            <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="multipass launch --name microstack-vm --mem 8G --disk 40G" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-          </li>
-          <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Install the MicroStack snap on that Multipass VM</h3>
-
-            <div class="p-code-copyable u-stepped-list-margin">
-              <input class="p-code-copyable__input" value="multipass exec microstack-vm -- sudo snap install microstack --beta --devmode"
-                readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-          </li>
-          <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
-
+            <h3 class="p-stepped-list__title">Set up MicroStack</h3>
             <div class="p-code-copyable u-stepped-list-margin">
               <input class="p-code-copyable__input" value="sudo microstack init --auto --control" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -312,7 +275,6 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
           </li>
           <li class="p-stepped-list__item">
             <h3 class="p-stepped-list__title">Launch a VM</h3>
-
             <div class="p-code-copyable u-stepped-list-margin">
               <input class="p-code-copyable__input" value="microstack launch cirros --name test" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -322,13 +284,85 @@ https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/
           </li>
         </ol>
         <p>
-          That’s it! Your OpenStack is ready.
+          That’s it! Your micro cloud is ready.
+        </p>
+      </div>
+      <div class="col-8 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
+        <ol class="p-stepped-list u-no-margin--left">
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Install Multipass</h3>
+            <p class="p-stepped-list__content u-stepped-list-margin">
+              <a href="https://multipass.run/download/macos" class="p-button--positive" data-os="mac">
+                Download
+              </a>
+            </p>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Get a VM with Linux</h3>
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" value="multipass launch --name microstack-vm --mem 8G --disk 100G" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Install MicroStack</h3>
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" value="multipass exec microstack-vm -- sudo snap install microstack --beta --devmode" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" value="sudo microstack init --auto --control" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">Launch a VM</h3>
+            <div class="p-code-copyable u-stepped-list-margin">
+              <input class="p-code-copyable__input" value="microstack launch cirros --name test" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
+            </div>
+            <p>Your VM is up and running now. You should see a message like:</p>
+            <p>Access your server with <code class="highlighter-rouge">ssh -i /home/ubuntu/snap/microstack/common/.ssh/id_microstack cirros@10.20.20.3</code></p>
+          </li>
+        </ol>
+        <p>
+          That’s it! Your micro cloud is ready.
+        </p>
+      </div>
+    </div>
+  </section>
+  <section class="p-strip--light">
+    <div class="row u-vertically-center">
+      <div class="col-6">
+        <h2>The team behind MicroStack</h2>
+        <p>MicroStack is maintained by the <a class="p-link--external" href="https://ubuntu.com/openstack">OpenStack team at Canonical</a>. We provide OpenStack packages on Ubuntu and have two OpenStack distributions of our own. MicroStack is an on-rails, opinionated OpenStack for the edge, micro clouds and developers. <a class="p-link--external" href="https://ubuntu.com/openstack/features">Charmed OpenStack</a> is a composable enterprise OpenStack for large scale deployments in data centres.</p>
+      </div>
+      <div class="col-5 u-hide--small u-align--center">
+        <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="Canonical" style="width : 160px; height:160px">
+      </div>
+    </div>
+  </section>
+  <section class="p-strip is-deep">
+    <div class="row u-vertically-center">
+      <div class="col-5 u-hide--small u-align--center">
+        <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" alt="Contact us" style="width : 240px; height:171px">
+      </div>
+      <div class="col-7">
+        <h2>Get in touch</h2>
+        <p>Let’s talk about your edge and micro cloud plans.</p>
+        <p>
+          <a class="p-button--positive" href="https://ubuntu.com/openstack/contact-us">
+            Contact us
+          </a>
         </p>
       </div>
     </div>
   </section>
 </main>
-
+<script src="{{ versioned_static('js/typer.js') }}" defer></script>
 <script defer src="{{ versioned_static('js/tabs.js') }}"></script>
 
 {% endblock %}

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -16,10 +16,13 @@
             <a href="/docs">Docs</a>
           </li>
           <li class="p-navigation__link" role="menuitem">
-            <a class="p-link--external" href="https://opendev.org/x/microstack">Code</a>
+            <a class="p-link--external" href="https://opendev.org/x/microstack">Contribute</a>
           </li>
           <li class="p-navigation__link" role="menuitem">
-            <a class="p-link--external" href="https://bugs.launchpad.net/microstack">Bugs</a>
+            <a class="p-link--external" href="https://bugs.launchpad.net/microstack/+filebug">Report a bug</a>
+          </li>
+          <li class="p-navigation__link" role="menuitem">
+            <a class="p-link--external" href="https://discourse.charmhub.io/search?q=microstack">Community</a>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
## Done

Rebuild MicroStack home page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check page against [copy doc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit) and and resolve comments
- Check against [design](https://app.zeplin.io/project/611e22af1491325814021275/screen/611e22e82bc2085acc4bc1df)

## Issue / Card

Fixes [#4351](https://github.com/canonical-web-and-design/web-squad/issues/4351)

## Screenshots
<img width="1440" alt="MicroStack - OpenStack in a snap ()" src="https://user-images.githubusercontent.com/57550290/131124842-bcd602cb-211d-40c8-8918-54e42a3436ef.png">


