### PR TITLE
Update to node 16 for production docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:12 AS yarn-dependencies
+FROM node:16 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install


### PR DESCRIPTION
Node 16 is latest LTS, we should be using it everywhere.

## QA

It works, I checked it! But you can too!

``` bash
docker build -t microstacknode16 .
docker run --env SECRET_KEY=dfgsdf -ti -p 8080:80 microstacknode16
```

Go to http://localhost:8080. Check the site works.