### PR TITLE
Homepage copy updates

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -60,7 +60,7 @@
   <meta name="twitter:description" content="{% if description %}{{ description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">
   <meta property="og:title" content="{% if title %}{{ title }} | MicroStack{% else %}MicroStack - OpenStack in a snap{% endif %}">
   <meta property="og:description" content="{% if description %}{{ description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">
-  <meta name="copydoc" content="{{ meta_copydoc }}">
+  <meta name="copydoc" content="{% block meta_copydoc %}https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit{% endblock %}">
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,9 +5,7 @@
 MicroStack is a micro cloud solution based on OpenStack, designed for the edge and small-scale private cloud deployments, that can be installed and maintained with a minimal effort.
 {% endblock %}
 
-{% block meta_copydoc %}
-https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit
-{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit{% endblock %}
 
 {% block content %}
 <script defer src="{{ versioned_static('js/copy-to-clipboard.js') }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 {% block title %}OpenStack for the edge, micro clouds and developers{% endblock %}
 
 {% block description %}
-MicroStack is a micro cloud solution based on OpenStack, designed for the edge and small-scale private cloud deployments, that can be installed and maintained with a minimal effort.
+MicroStack is a pure upstream OpenStack platform, designed for the edge and small-scale private cloud deployments, that can be installed and maintained with a minimal effort.
 {% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit{% endblock %}
@@ -306,7 +306,7 @@ MicroStack is a micro cloud solution based on OpenStack, designed for the edge a
             </div>
           </li>
           <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">Configure networks and OpenStack databases</h3>
+            <h3 class="p-stepped-list__title">Set up MicroStack</h3>
             <div class="p-code-copyable u-stepped-list-margin">
               <input class="p-code-copyable__input" value="sudo microstack init --auto --control" readonly="readonly">
               <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -332,7 +332,7 @@ MicroStack is a micro cloud solution based on OpenStack, designed for the edge a
     <div class="row u-vertically-center">
       <div class="col-6">
         <h2>The team behind MicroStack</h2>
-        <p>MicroStack is maintained by the <a class="p-link--external" href="https://ubuntu.com/openstack">OpenStack team at Canonical</a>. We provide OpenStack packages on Ubuntu and have two OpenStack distributions of our own. MicroStack is an on-rails, opinionated OpenStack for the edge, micro clouds and developers. <a class="p-link--external" href="https://ubuntu.com/openstack/features">Charmed OpenStack</a> is a composable enterprise OpenStack for large scale deployments in data centres. MicroStack was built by the dedicated OpenStack team at Canonical for the developer community. We also make the Charmed OpenStack for multi-cloud scalable clusters. Please contact us if you have any questions. </p>
+        <p>MicroStack is maintained by the <a class="p-link--external" href="https://ubuntu.com/openstack">OpenStack team at Canonical</a>. We provide OpenStack packages on Ubuntu and have two OpenStack distributions of our own. MicroStack is an on-rails, opinionated OpenStack for the edge, micro clouds and developers. <a class="p-link--external" href="https://ubuntu.com/openstack/features">Charmed OpenStack</a> is a composable enterprise OpenStack for large scale deployments in data centres.</p>
       </div>
       <div class="col-5 u-hide--small u-align--center">
         <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="Canonical" style="width : 160px; height:160px">

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,8 +1,5 @@
 <footer class="p-strip--light">
   <div class="row">
-    <p>
-        MicroStack was built by the dedicated <a class="p-link--external" href="https://www.ubuntu.com/openstack">OpenStack team at Canonical</a> for the developer community. We also make <a class="p-link--external" href="https://jaas.ai/openstack">Charmed OpenStack</a> for multi-cloud scalable clusters. Please <a class="p-link--external" href="https://ubuntu.com/openstack/contact-us">contact us</a> if you have any questions.
-    </p>
     <p class="u-no-max-width">
         &copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.
     </p>


### PR DESCRIPTION
## Done

- Updated the homepage with changes requested in the [copy doc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit)
- Fixed the copydoc metatag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page matches the copy doc (note: the comments around images and quotes aren't addressed in this PR, I've asked Tytus if they're still valid and am waiting on a response)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4740
