### PR TITLE
Update index meta description copy

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -49,7 +49,7 @@
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2" crossorigin>
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
 
-  <meta name="description" content="{% if description %}{{ description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">
+  <meta name="description" content="{% if description %}{{ description }}{% else %}MicroStack is a pure upstream OpenStack platform, designed for the edge and small-scale private cloud deployments, that can be installed and maintained with a minimal effort.{% endif %}">
   <meta name="theme-color" content="#E95420">
   <meta name="twitter:account_id" content="4503599627481511">
   <meta name="twitter:site" content="@ubuntu">
@@ -57,9 +57,9 @@
   <meta property="og:url" content="http://microstack.run">
   <meta property="og:site_name" content="microstack.run">
   <meta name="twitter:title" content="{% if title %}{{ title }} | MicroStack{% else %}OpenStack for the edge, micro clouds and developers{% endif %}">
-  <meta name="twitter:description" content="{% if description %}{{ description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">
+  <meta name="twitter:description" content="{% if description %}{{ description }}{% else %}MicroStack is a pure upstream OpenStack platform, designed for the edge and small-scale private cloud deployments, that can be installed and maintained with a minimal effort.{% endif %}">
   <meta property="og:title" content="{% if title %}{{ title }} | MicroStack{% else %}OpenStack for the edge, micro clouds and developers{% endif %}">
-  <meta property="og:description" content="{% if description %}{{ description }}{% else %}MicroStack is an upstream single-node OpenStack deployment which can run directly on your workstation. Although made for developers, it is also suitable for edge, IoT and appliances.{% endif %}">
+  <meta property="og:description" content="{% if description %}{{ description }}{% else %}MicroStack is a pure upstream OpenStack platform, designed for the edge and small-scale private cloud deployments, that can be installed and maintained with a minimal effort.{% endif %}">
   <meta name="copydoc" content="{% block meta_copydoc %}https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit{% endblock %}">
 </head>
 <body>


### PR DESCRIPTION
## Done

- Updated the meta description according to the [copy doc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Inspect the page source and see that the meta tags for `description`, `twitter:description` and `og:description` have been updated and match the copy doc

## Issue / Card

Fixes [#4758](https://github.com/canonical-web-and-design/web-squad/issues/4758)