### PR TITLE
Added openstack tutorials link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -40,7 +40,7 @@ MicroStack is a pure upstream OpenStack platform, designed for the edge and smal
       </div>
       <div class="row-cli__commands">$ sudo<span class="row-cli__commands-list typer" id="main" data-words="snap install microstack --beta --devmode,microstack init --auto --control" data-delay="50" data-deleteDelay="5000" data-colors="#111111"></span></div>
       <p>
-        <a class="p-link--external" href="https://ubuntu.com/tutorials/microstack-get-started#1-overview">MicroStack tutorial</a>
+        <a class="p-link--external" href="https://ubuntu.com/openstack/tutorials">MicroStack tutorial</a>
       </p>
     </div>
   </section>
@@ -233,7 +233,7 @@ MicroStack is a pure upstream OpenStack platform, designed for the edge and smal
           </li>
         </ol>
         <p>
-          That’s it! Your micro cloud is ready.
+          That’s it! Your micro cloud is ready. You can now follow with <a href="https://ubuntu.com/openstack/tutorials" class="p-link--external">MicroStack tutorials</a>.
         </p>
       </div>
       <div class="col-9 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
@@ -278,7 +278,7 @@ MicroStack is a pure upstream OpenStack platform, designed for the edge and smal
           </li>
         </ol>
         <p>
-          That’s it! Your micro cloud is ready.
+          That’s it! Your micro cloud is ready. You can now follow with <a href="https://ubuntu.com/openstack/tutorials" class="p-link--external">MicroStack tutorials</a>.
         </p>
       </div>
       <div class="col-9 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
@@ -323,7 +323,7 @@ MicroStack is a pure upstream OpenStack platform, designed for the edge and smal
           </li>
         </ol>
         <p>
-          That’s it! Your micro cloud is ready.
+          That’s it! Your micro cloud is ready. You can now follow with <a href="https://ubuntu.com/openstack/tutorials" class="p-link--external">MicroStack tutorials</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

Updated index as per [copy doc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Demo: https://microstack-run-162.demos.haus
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check against copy doc and make sure all comments have been addressed 
- Check that links work as expected 


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4754