### PR TITLE
Update installation instructions to remove `devmode`

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -40,7 +40,7 @@ MicroStack is a pure upstream OpenStack platform, designed for the edge and smal
         <h2>Straightforward installation</h2>
         <h3 class="p-heading--4">Fully functional OpenStack in 2 commands and ~20 minutes.</h3>
       </div>
-      <div class="row-cli__commands">$ sudo<span class="row-cli__commands-list typer" id="main" data-words="snap install microstack --beta --devmode,microstack init --auto --control" data-delay="50" data-deleteDelay="5000" data-colors="#111111"></span></div>
+      <div class="row-cli__commands">$ sudo<span class="row-cli__commands-list typer" id="main" data-words="snap install microstack --beta,microstack init --auto --control" data-delay="50" data-deleteDelay="5000" data-colors="#111111"></span></div>
       <p>
         <a href="https://ubuntu.com/openstack/tutorials">MicroStack tutorial</a>
       </p>
@@ -216,7 +216,7 @@ MicroStack is a pure upstream OpenStack platform, designed for the edge and smal
             <h3 class="p-stepped-list__title u-sv2">Install MicroStack</h3>
             <div class="p-stepped-list__content">
               <div class="p-code-snippet">
-                <pre class="p-code-snippet__block--icon"><code>sudo snap install microstack --beta --devmode</code></pre>
+                <pre class="p-code-snippet__block--icon"><code>sudo snap install microstack --beta</code></pre>
               </div>
               <p><code>snap</code> command not found? <a href="https://docs.snapcraft.io/installing-snapd">Install snapd</a>.</p>
             </div>
@@ -267,7 +267,7 @@ MicroStack is a pure upstream OpenStack platform, designed for the edge and smal
             <h3 class="p-stepped-list__title u-sv2">Install MicroStack</h3>
             <div class="p-stepped-list__content">
               <div class="p-code-snippet">
-                <pre class="p-code-snippet__block--icon"><code>multipass exec microstack-vm -- sudo snap install microstack --beta --devmode</code></pre>
+                <pre class="p-code-snippet__block--icon"><code>multipass exec microstack-vm -- sudo snap install microstack --beta</code></pre>
               </div>
             </div>
           </li>
@@ -316,7 +316,7 @@ MicroStack is a pure upstream OpenStack platform, designed for the edge and smal
             <h3 class="p-stepped-list__title u-sv2">Install MicroStack</h3>
             <div class="p-stepped-list__content">
               <div class="p-code-snippet">
-                <pre class="p-code-snippet__block--icon"><code>multipass exec microstack-vm -- sudo snap install microstack --beta --devmode</code></pre>
+                <pre class="p-code-snippet__block--icon"><code>multipass exec microstack-vm -- sudo snap install microstack --beta</code></pre>
               </div>
             </div>
           </li>


### PR DESCRIPTION
## Done

- Updated page as per [copy doc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit#heading=h.dsxw6o6hnq74)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- See that the requested changes have been made (have to click through each OS option)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5025
